### PR TITLE
Fix display error in bypassed ip list

### DIFF
--- a/files/luci/model/cbi/shadowsocks/access-control.lua
+++ b/files/luci/model/cbi/shadowsocks/access-control.lua
@@ -17,7 +17,7 @@ o = s:option(Value, "wan_bp_list", translate("Bypassed IP List"))
 o:value("/dev/null", translate("NULL - As Global Proxy"))
 if chnroute then o:value(chnroute, translate("ChinaDNS CHNRoute")) end
 o.datatype = "or(file, '/dev/null')"
-o.default = chnroute or "/dev/null"
+o.default = "/dev/null"
 o.rmempty = false
 
 o = s:option(DynamicList, "wan_bp_ips", translate("Bypassed IP"))


### PR DESCRIPTION
"Chinadns" is displayed by default in bypassed IP list , but it works as global proxy if  "Sava & Apply" button  in access control page is not clicked.
Normally people wont click 'Save' if settings are already what they want.