### PR TITLE
luci-app-shadowsocks: use new extra_command function for init

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=luci-app-shadowsocks
 PKG_VERSION:=1.9.1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_LICENSE:=GPLv3
 PKG_LICENSE_FILES:=LICENSE

--- a/files/root/etc/init.d/shadowsocks
+++ b/files/root/etc/init.d/shadowsocks
@@ -10,7 +10,7 @@ START=90
 STOP=15
 
 NAME=shadowsocks
-EXTRA_COMMANDS=rules
+extra_command "rules"
 
 uci_get_by_name() {
 	local ret=$(uci get $NAME.$1.$2 2>/dev/null)


### PR DESCRIPTION
use new extra_command function for init because of https://github.com/openwrt/openwrt/commit/1a69f50dc627f6fc5860f871edec357cc0a187e6